### PR TITLE
Fix routes of sources

### DIFF
--- a/app/Http/Controllers/SourceController.php
+++ b/app/Http/Controllers/SourceController.php
@@ -18,6 +18,7 @@ class SourceController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        DB::enableQueryLog();
     }
     /**
      * Display a listing of the resource.
@@ -115,7 +116,7 @@ class SourceController extends Controller
     public function edit(source $source)
     {
 
-        dd(DB::getQueryLog());
+        //dd(DB::getQueryLog());
         return view('livres.edit',
             ['source' => $source]
         );

--- a/resources/views/livres/edit.blade.php
+++ b/resources/views/livres/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="container">
-        <form action="{{route('home.update', $source)}}" method="POST">
+        <form action="{{route('sources.update', $source)}}" method="POST">
             <input type="hidden" name="_method" value="PUT">
             {{csrf_field()}}
             <div class="card-body row">
@@ -104,7 +104,7 @@
             {{--        </div>--}}
 
             <div class="card-body row">
-                <input class="form-control col" type="text" maxlength="150" name="Title_Livre" value="{{$source}}">
+                <input class="form-control col" type="text" maxlength="150" name="Title_Livre" value="{{$source->id}}">
             </div>
 
             <div class="card-body row">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,9 @@ Route::get('/', function () {
 
 Auth::routes();
 
-Route::resource('/home','SourceController');
+Route::prefix('home')->group(function () {
+    Route::resource('sources', 'SourceController');
+});
 
 //Route::resource('home/livres', 'LivreController');
 


### PR DESCRIPTION
В `routes/web.php` есть строка:

```php
Route::resource('/home','SourceController');
```

Выполняем в консоли:

```bash
php artisan route:list
```

Читаем:

```bash
+--------+-----------+------------------------+------------------+------------------------------------------------------------------------+--------------+
| Domain | Method    | URI                    | Name             | Action                                                                 | Middleware   |
+--------+-----------+------------------------+------------------+------------------------------------------------------------------------+--------------+
|        | GET|HEAD  | home/{home}/edit       | home.edit        | App\Http\Controllers\SourceController@edit                             | web,auth     |
+--------+-----------+------------------------+------------------+------------------------------------------------------------------------+--------------+
```

Видно, что у маршрута есть параметр `{home}`. Laravel придумал его имя на основе префикса (`/home`), т. к. Вы воспользовались методом автоматической маршрутизации для ресурсного контроллера (`Route::resource`). Laravel автоматически передаёт значение параметра маршрута в соответствующий метод контроллера (`SourceController@edit`), если у того есть **одноимённый** аргумент. Если бы этот метод имел вид

```php
public function edit($home)
{
    var_dump($home);
}
```

то при обращении на <http://127.0.0.1:8000/home/123/edit> на экран выводилась бы строка с числом `123`.

Кроме того, если в методе указан тип параметра (например, интерфейс) или имя класса, то Laravel воспримет значение параметра как первичный ключ, определит имя таблицы БД через класс и автоматически сделает выборку по ID:

```php
public function edit(Source $home)
{
    var_dump($home);
}
```

В общем, нужно следить за тем, чтобы имя параметра в маршруте (сейчас это `{home}`) совпадало с именем аргумента (любого по счёту) в соответствующем методе контроллера. Сейчас у аргумента имя `$source`, поэтому автоматическая выборка сломана.

Понятно, что `$home` ⁠— плохое имя для переменной, хранящей объект класса `Source`. Поэтому предлагаю по-другому указать маршрут в `routes/web.php`: вместо

```php
Route::resource('/home','SourceController');
```

написать

```php
Route::prefix('home')->group(function () {
    Route::resource('sources', 'SourceController');
});
```

Отныне `Route::resource` будет получать префикс `sources` и, соответственно, будет использовать переменную `$source`. Адрес для формы редактирования приобретёт вид <http://127.0.0.1:8000/home/sources/1/edit>, но это как раз более правильно с точки зрения [REST](https://code.tutsplus.com/ru/tutorials/a-beginners-guide-to-http-and-rest--net-16340). Это касается и имён маршрутов (в шаблонах придётся писать `{{ route('sources.update', $source) }}` вместо `{{ route('home.update', $source) }}`), но и это неплохо, т. к. повышает переносимость (имена маршрутов не должны зависеть от URL).

P.S. Кстати, Вы сделали `dd(DB::getQueryLog());`, но `DB::enableQueryLog();` предварительно (до запроса) не вызвали, и поэтому ничего не выводится. Вызовите, например, внутри контруктора (`__construct()`) ⁠— это единственный метод, который гарантировано вызывается при создании объекта контроллера (при каждом запросе).